### PR TITLE
After rejecting alumni request, refreshing admin page shows the request again — not deleted from database

### DIFF
--- a/src/utils/direct-mongodb-test.js
+++ b/src/utils/direct-mongodb-test.js
@@ -7,7 +7,7 @@ const path = require('path');
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
 
 // Try a direct connection string
-const uri = "mongodb+srv://developerwecannita:developerwecannita@25@cluster0.2wnqs.mongodb.net/?retryWrites=true&w=majority";
+const uri = "mongodb+srv://developerwecannita:<db_password_change_this>@cluster0.2wnqs.mongodb.net/?retryWrites=true&w=majority";
 
 // Create a new MongoClient
 const client = new MongoClient(uri, {


### PR DESCRIPTION
Problem
When an admin rejected an alumni request, the request would temporarily disappear from the UI. However, refreshing the page caused the rejected request to reappear, indicating it was never properly removed from the database.

Root Cause
The rejection flow was updating the alumni record's isApproved field to false instead of deleting it